### PR TITLE
fix dependency of kendra

### DIFF
--- a/cdk/lib/constructs/kendra-s3-data-source.ts
+++ b/cdk/lib/constructs/kendra-s3-data-source.ts
@@ -46,5 +46,7 @@ export class KendraS3DataSource extends Construct {
       },
       schedule: 'cron(0 15 * * ? *)', // 毎日0:00(JST)
     })
+
+    this.dataSource.addDependency(props.index);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

docs/10_DEPLOYMENT.md の「4.3. デプロイを実行します。」において、
Cfnでスタックをデプロイする時にKendraのDatasource作成でエラーになった

```text
KendraBoxConnectorStack | 18/30 | 11:10:52 AM | CREATE_FAILED        | AWS::Kendra::DataSource         | KendraS3DataSource/Default (KendraS3DataSource) Cannot fulfill the request since provided index with name KendraIndex (ID: ***) is not in a valid state. (Service: Kendra, Status Code: 400, Request ID: ***)
KendraBoxConnectorStack | 18/30 | 11:10:53 AM | CREATE_FAILED        | AWS::Kendra::Index              | KendraIndex/Default (KendraIndex) Resource creation cancelled
```

これはKendraにおける既知の問題で、DatasourceにIndexに対するDependencyを追加する必要がある。
（追加しないと、デプロイ時におけるリソース作成のタイミングによって、デプロイが失敗することがある）

*Description of changes:*

KendraS3DataSourceコンストラクトにおいて、addDependencyの処理を追加した

*動作確認*
作成に失敗したStackを削除し、addDependencyの処理を追加した後に再度デプロイしたら、エラーなくデプロイできた


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
